### PR TITLE
Add Weight of the shipment

### DIFF
--- a/guides/m1x/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html
+++ b/guides/m1x/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html
@@ -64,6 +64,11 @@ title: Shipment Add Track
 <td> trackNumber <br class="atl-forced-newline" /> </td>
 <td> Tracking number </td>
 </tr>
+<tr>
+<td> double <br class="atl-forced-newline" /> </td>
+<td> weight <br class="atl-forced-newline" /> </td>
+<td> Weight of the shipment (optional) </td>
+</tr>
 </tbody></table>
 
 


### PR DESCRIPTION
## This PR is a

- [ ] New topic
- [x] Content update
- [ ] Content fix or rewrite
- [ ] Bug fix or improvement

## Summary

This add the weight of the shipment for https://github.com/OpenMage/magento-lts/pull/1377.
Link to [online doc](https://devdocs-openmage.org/guides/m1x//api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html).