### PR TITLE
Remove target blank for SOAP API index

### DIFF
--- a/guides/m1x/api/soap-api-index.html
+++ b/guides/m1x/api/soap-api-index.html
@@ -5,207 +5,207 @@ title: Magento 1.x SOAP API
 
 <p>Welcome to the Magento 1.x SOAP API home page.</p>
 
-	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/introduction.html" target="_blank">Introduction to the Magento 1.x SOAP API</a></li>
-		<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalog.html" target="_blank">Catalog</a></strong></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalogCategory.html" target="_blank">Catalog Category</a></li>
-			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignedProducts.html" target="_blank">Assigned Products</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignProduct.html" target="_blank">Assign Product</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.create.html" target="_blank">Create Category</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.currentStore.html" target="_blank">Current Store</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.delete.html" target="_blank">Category Delete</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.info.html" target="_blank">Category Info</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.level.html" target="_blank">Category Level</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.move.html" target="_blank">Category Move</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.removeProduct.html" target="_blank">Remove Product</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.tree.html" target="_blank">Category Tree</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.update.html" target="_blank">Category Update</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.updateProduct.html" target="_blank">Category Product Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/categoryAttributes.html" target="_blank">Category Attributes</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.currentStore.html" target="_blank">Current Store</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.list.html" target="_blank">Attribute List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.options.html" target="_blank">Attribute Options</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalogProduct.html" target="_blank">Catalog Product</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.create.html" target="_blank">Product Create</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.currentStore.html" target="_blank">Current Product Store</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.delete.html" target="_blank">Product Delete</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.getSpecialPrice.html" target="_blank">Get Special Price</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.info.html" target="_blank">Product Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.list.html" target="_blank">Product List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.listOfAdditionalAttributes.html" target="_blank">List of Additional Attributes</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html" target="_blank">Set Special Price</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.update.html" target="_blank">Product Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/catalogProductAttribute.html" target="_blank">Catalog Product Attribute</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.addOption.html" target="_blank">Add Option</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.create.html" target="_blank">Create Attribute</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.currentStore.html" target="_blank">Current Store</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.info.html" target="_blank">Attribute Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.list.html" target="_blank">Attribute List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.options.html" target="_blank">Attribute Options</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.remove.html" target="_blank">Attribute Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.removeOption.html" target="_blank">Remove Option</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.types.html" target="_blank">Attribute Types</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.update.html" target="_blank">Attribute Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/productImages.html" target="_blank">Catalog Product Attribute Media</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.create.html" target="_blank">Create</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.currentStore.html" target="_blank">Current Store</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.info.html" target="_blank">Media Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html" target="_blank">Media List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.remove.html" target="_blank">Media Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.types.html" target="_blank">Media Types</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.update.html" target="_blank">Media Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/productAttributeSet.html" target="_blank">Product Attribute Set</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeAdd.html" target="_blank">Attribute Set Add</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeRemove.html" target="_blank">Attribute Set Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html" target="_blank">Attribute Set Create</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupAdd.html" target="_blank">Attribute Set Group Add</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRemove.html" target="_blank">Attribute Set Group Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRename.html" target="_blank">Attribute Set Group Rename</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.list.html" target="_blank">Attribute Set List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.remove.html" target="_blank">Attribute Set Remove</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/catalogProductCustomOption.html" target="_blank">Catalog Product Custom Option</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.add.html" target="_blank">Product Custom Option Add</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.info.html" target="_blank">Product Custom Option Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.list.html" target="_blank">Product Custom Option List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.remove.html" target="_blank">Product Custom Option Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.types.html" target="_blank">Product Custom Option Types</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.update.html" target="_blank">Product Custom Option Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/catalogProductCustomOptionValue.html" target="_blank">Catalog Product Custom Option Value</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.add.html" target="_blank">Product Custom Option Value Add</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.info.html" target="_blank">Product Custom Option Value Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.list.html" target="_blank">Product Custom Option Value List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.remove.html" target="_blank">Product Custom Option Value Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.update.html" target="_blank">Product Custom Option Value Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/catalogProductDownloadableLink.html" target="_blank">Catalog Product Downloadable Link</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.add.html" target="_blank">Downloadable Link Add</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.list.html" target="_blank">Downloadable Link List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.remove.html" target="_blank">Downloadable Link Remove</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalogProductLink.html" target="_blank">Catalog Product Link</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.assign.html" target="_blank">Product Link Assign</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.attributes.html" target="_blank">Product Link Attributes</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.list.html" target="_blank">Product Link List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.remove.html" target="_blank">Product Link Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.types.html" target="_blank">Product Link Types</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.update.html" target="_blank">Product Link Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/catalogProductTag.html" target="_blank">Catalog Product Tag</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.add.html" target="_blank">Product Tag Add</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.info.html" target="_blank">Product Tag Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.list.html" target="_blank">Product Tag List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.remove.html" target="_blank">Product Tag Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.update.html" target="_blank">Product Tag Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalogProductTierPrice.html" target="_blank">Catalog Product Attribute Tier Price</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.info.html" target="_blank">Product Attribute Tier Price Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.update.html" target="_blank">Product Attribute Tier Price Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/productTypes.html" target="_blank">Catalog Product Types</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/catalog_product_type.list.html" target="_blank">Product Type List</a></li></ul>
+	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/introduction.html">Introduction to the Magento 1.x SOAP API</a></li>
+		<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalog.html">Catalog</a></strong></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalogCategory.html">Catalog Category</a></li>
+			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignedProducts.html">Assigned Products</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.assignProduct.html">Assign Product</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.create.html">Create Category</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.currentStore.html">Current Store</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.delete.html">Category Delete</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.info.html">Category Info</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.level.html">Category Level</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.move.html">Category Move</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.removeProduct.html">Remove Product</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.tree.html">Category Tree</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.update.html">Category Update</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategory/catalog_category.updateProduct.html">Category Product Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/categoryAttributes.html">Category Attributes</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.currentStore.html">Current Store</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.list.html">Attribute List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogCategoryAttributes/catalog_category_attribute.options.html">Attribute Options</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalogProduct.html">Catalog Product</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.create.html">Product Create</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.currentStore.html">Current Product Store</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.delete.html">Product Delete</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.getSpecialPrice.html">Get Special Price</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.info.html">Product Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.list.html">Product List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.listOfAdditionalAttributes.html">List of Additional Attributes</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.setSpecialPrice.html">Set Special Price</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProduct/catalog_product.update.html">Product Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/catalogProductAttribute.html">Catalog Product Attribute</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.addOption.html">Add Option</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.create.html">Create Attribute</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.currentStore.html">Current Store</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.info.html">Attribute Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.list.html">Attribute List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.options.html">Attribute Options</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.remove.html">Attribute Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.removeOption.html">Remove Option</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.types.html">Attribute Types</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttribute/product_attribute.update.html">Attribute Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/productImages.html">Catalog Product Attribute Media</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.create.html">Create</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.currentStore.html">Current Store</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.info.html">Media Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.list.html">Media List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.remove.html">Media Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.types.html">Media Types</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeMedia/catalog_product_attribute_media.update.html">Media Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/productAttributeSet.html">Product Attribute Set</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeAdd.html">Attribute Set Add</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.attributeRemove.html">Attribute Set Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.create.html">Attribute Set Create</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupAdd.html">Attribute Set Group Add</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRemove.html">Attribute Set Group Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.groupRename.html">Attribute Set Group Rename</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.list.html">Attribute Set List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductAttributeSet/product_attribute_set.remove.html">Attribute Set Remove</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/catalogProductCustomOption.html">Catalog Product Custom Option</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.add.html">Product Custom Option Add</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.info.html">Product Custom Option Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.list.html">Product Custom Option List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.remove.html">Product Custom Option Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.types.html">Product Custom Option Types</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOption/product_custom_option.update.html">Product Custom Option Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/catalogProductCustomOptionValue.html">Catalog Product Custom Option Value</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.add.html">Product Custom Option Value Add</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.info.html">Product Custom Option Value Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.list.html">Product Custom Option Value List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.remove.html">Product Custom Option Value Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductCustomOptionValue/product_custom_option_value.update.html">Product Custom Option Value Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/catalogProductDownloadableLink.html">Catalog Product Downloadable Link</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.add.html">Downloadable Link Add</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.list.html">Downloadable Link List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductDownloadableLink/product_downloadable_link.remove.html">Downloadable Link Remove</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalogProductLink.html">Catalog Product Link</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.assign.html">Product Link Assign</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.attributes.html">Product Link Attributes</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.list.html">Product Link List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.remove.html">Product Link Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.types.html">Product Link Types</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductLink/catalog_product_link.update.html">Product Link Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/catalogProductTag.html">Catalog Product Tag</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.add.html">Product Tag Add</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.info.html">Product Tag Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.list.html">Product Tag List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.remove.html">Product Tag Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTag/product_tag.update.html">Product Tag Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalogProductTierPrice.html">Catalog Product Attribute Tier Price</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.info.html">Product Attribute Tier Price Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTierPrice/catalog_product_attribute_tier_price.update.html">Product Attribute Tier Price Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/productTypes.html">Catalog Product Types</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalog/catalogProductTypes/catalog_product_type.list.html">Product Type List</a></li></ul>
 	</ul>
-	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/Inventory.html" target="_blank">Catalog Inventory</a></strong></li>
-	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.list.html" target="_blank">Inventory Stock Item List</a></li>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.update.html" target="_blank">Inventory Stock Item Update</a></li></ul>
-	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/checkout/checkout.html" target="_blank">Checkout</a></strong></li>
-	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.html" target="_blank">Cart</a></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.create.html" target="_blank">Cart Create</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.info.html" target="_blank">Cart Info</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.license.html" target="_blank">Cart License</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.order.html" target="_blank">Cart Order</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.totals.html" target="_blank">Cart Totals</a></li></ul>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cartCoupon.html" target="_blank">Cart Coupon</a></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.add.html" target="_blank">Coupon Add</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.remove.html" target="_blank">Coupon Remove</a></li></ul>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cartCustomer.html" target="_blank">Cart Customer</a></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.addresses.html" target="_blank">Customer Addresses</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.set.html" target="_blank">Customer Set</a></li></ul>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cartPayment.html" target="_blank">Cart Payment</a></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.list.html" target="_blank">Payment List</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.method.html" target="_blank">Payment Method</a></li></ul>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cartProduct.html" target="_blank">Cart Product</a></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.add.html" target="_blank">Product Add</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.list.html" target="_blank">Product List</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.moveToCustomerQuote.html" target="_blank">Product Move To Customer Quote</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.remove.html" target="_blank">Product Remove</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.update.html" target="_blank">Product Update</a></li></ul>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cartShipping.html" target="_blank">Cart Shipping</a></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.list.html" target="_blank">Shipping List</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.method.html" target="_blank">Shipping Method</a></li></ul>
+	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/Inventory.html">Catalog Inventory</a></strong></li>
+	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.list.html">Inventory Stock Item List</a></li>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/catalogInventory/cataloginventory_stock_item.update.html">Inventory Stock Item Update</a></li></ul>
+	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/checkout/checkout.html">Checkout</a></strong></li>
+	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.html">Cart</a></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.create.html">Cart Create</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.info.html">Cart Info</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.license.html">Cart License</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.order.html">Cart Order</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cart/cart.totals.html">Cart Totals</a></li></ul>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cartCoupon.html">Cart Coupon</a></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.add.html">Coupon Add</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCoupon/cart_coupon.remove.html">Coupon Remove</a></li></ul>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cartCustomer.html">Cart Customer</a></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.addresses.html">Customer Addresses</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartCustomer/cart_customer.set.html">Customer Set</a></li></ul>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cartPayment.html">Cart Payment</a></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.list.html">Payment List</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartPayment/cart_payment.method.html">Payment Method</a></li></ul>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cartProduct.html">Cart Product</a></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.add.html">Product Add</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.list.html">Product List</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.moveToCustomerQuote.html">Product Move To Customer Quote</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.remove.html">Product Remove</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartProduct/cart_product.update.html">Product Update</a></li></ul>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cartShipping.html">Cart Shipping</a></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.list.html">Shipping List</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/checkout/cartShipping/cart_shipping.method.html">Shipping Method</a></li></ul>
 	</ul>
-	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/create_your_own_api.html" target="_blank">Create Your Own API</a></strong></li>
-	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.html" target="_blank">Customer</a></strong></li>
-	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer_group.html" target="_blank">Customer Group</a></li>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.create.html" target="_blank">Customer Create</a></li>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.delete.html" target="_blank">Customer Delete</a></li>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.info.html" target="_blank">Customer Info</a></li>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.list.html" target="_blank">Customer List</a></li>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.update.html" target="_blank">Customer Update</a></li>
-		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customerAddress.html" target="_blank">Customer Address</a></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.create.html" target="_blank">Address Create</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.delete.html" target="_blank">Address Delete</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.info.html" target="_blank">Address Info</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.list.html" target="_blank">Address List</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.update.html" target="_blank">Address Update</a></li></ul>
+	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/create_your_own_api.html">Create Your Own API</a></strong></li>
+	<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.html">Customer</a></strong></li>
+	<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer_group.html">Customer Group</a></li>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.create.html">Customer Create</a></li>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.delete.html">Customer Delete</a></li>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.info.html">Customer Info</a></li>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.list.html">Customer List</a></li>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customer.update.html">Customer Update</a></li>
+		<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customerAddress.html">Customer Address</a></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.create.html">Address Create</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.delete.html">Address Delete</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.info.html">Address Info</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.list.html">Address List</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/customer/customerAddress/customer_address.update.html">Address Update</a></li></ul>
 		</ul>
-		<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory.html" target="_blank">Directory</a></strong></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_country.list.html" target="_blank">Country List</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_region.list.html" target="_blank">Region List</a></li></ul>
-		<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/sales/sales.html" target="_blank">Sales</a></strong></li>
-		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/salesOrder.html" target="_blank">Sales Order</a></li>
-			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.addComment.html" target="_blank">Add Comment</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.cancel.html" target="_blank">Order Cancel</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.hold.html" target="_blank">Order Hold</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.info.html" target="_blank">Order Info</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.list.html" target="_blank">Order List</a></li>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.unhold.html" target="_blank">Order Unhold</a></li></ul>
-			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/salesOrderCreditMemo.html" target="_blank">Sales Order Credit Memo</a></li>
-			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.addComment.html" target="_blank">Add Comment</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.cancel.html" target="_blank">Memo Cancel</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.create.html" target="_blank">Memo Create</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.info.html" target="_blank">Memo Info</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.list.html" target="_blank">Memo List</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/salesOrderInvoice.html" target="_blank">Sales Order Invoice</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.addComment.html" target="_blank">Add Comment</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.cancel.html" target="_blank">Invoice Cancel</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.capture.html" target="_blank">Invoice Capture</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.create.html" target="_blank">Invoice Create</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.info.html" target="_blank">Invoice Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.list.html" target="_blank">Invoice List</a></li></ul>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/salesOrderShipment.html" target="_blank">Sales Order Shipment</a></li>
-					<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addComment.html" target="_blank">Add Comment</a></li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html" target="_blank">Add Track</a></li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.create.html" target="_blank">Shipment Create</a></li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.getCarriers.html" target="_blank">Shipment Get Carriers</a></li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.info.html" target="_blank">Shipment Info</a></li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.list.html" target="_blank">Shipment List</a></li>
-						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.removeTrack.html" target="_blank">Remove Track</a></li></ul>
+		<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory.html">Directory</a></strong></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_country.list.html">Country List</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/directory/directory_region.list.html">Region List</a></li></ul>
+		<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/sales/sales.html">Sales</a></strong></li>
+		<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/salesOrder.html">Sales Order</a></li>
+			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.addComment.html">Add Comment</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.cancel.html">Order Cancel</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.hold.html">Order Hold</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.info.html">Order Info</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.list.html">Order List</a></li>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrder/sales_order.unhold.html">Order Unhold</a></li></ul>
+			<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/salesOrderCreditMemo.html">Sales Order Credit Memo</a></li>
+			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.addComment.html">Add Comment</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.cancel.html">Memo Cancel</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.create.html">Memo Create</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.info.html">Memo Info</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderCreditMemo/sales_order_creditmemo.list.html">Memo List</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/salesOrderInvoice.html">Sales Order Invoice</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.addComment.html">Add Comment</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.cancel.html">Invoice Cancel</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.capture.html">Invoice Capture</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.create.html">Invoice Create</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.info.html">Invoice Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderInvoice/sales_order_invoice.list.html">Invoice List</a></li></ul>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/salesOrderShipment.html">Sales Order Shipment</a></li>
+					<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addComment.html">Add Comment</a></li>
+						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.addTrack.html">Add Track</a></li>
+						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.create.html">Shipment Create</a></li>
+						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.getCarriers.html">Shipment Get Carriers</a></li>
+						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.info.html">Shipment Info</a></li>
+						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.list.html">Shipment List</a></li>
+						<li><a href="{{ site.m1xgdeurl }}/api/soap/sales/salesOrderShipment/sales_order_shipment.removeTrack.html">Remove Track</a></li></ul>
 			</ul>
-			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/enterprise_customerbalance.html" target="_blank">Enterprise Customer Balance</a></strong></li>
-			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.html" target="_blank">Customer Balance</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.balance.html" target="_blank">Store Credit</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.history.html" target="_blank">Credit History</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.html" target="_blank">Shopping Cart Customer Balance</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.removeAmount.html" target="_blank">Balance Remove Amount</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.setAmount.html" target="_blank">Balance Set Amount</a></li></ul>
+			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/enterprise_customerbalance.html">Enterprise Customer Balance</a></strong></li>
+			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.html">Customer Balance</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.balance.html">Store Credit</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/customerBalance/storecredit.history.html">Credit History</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.html">Shopping Cart Customer Balance</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.removeAmount.html">Balance Remove Amount</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterprise_customerbalance/shoppingCartCustomerBalance/storecredit_quote.setAmount.html">Balance Set Amount</a></li></ul>
 			</ul>
-			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/enterprise_giftCard.html" target="_blank">Enterprise Gift Card</a></strong></li>
-			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cartGiftCard.html" target="_blank">Cart Gift Card</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.add.html" target="_blank">Gift Card Add</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.list.html" target="_blank">Gift Card List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.remove.html" target="_blank">Gift Card Remove</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftCardAccount.html" target="_blank">Gift Card Account</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.create.html" target="_blank">Account Create</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.info.html" target="_blank">Account Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.list.html" target="_blank">Account List</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.remove.html" target="_blank">Account Remove</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.update.html" target="_blank">Account Update</a></li></ul>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftCardCustomer.html" target="_blank">Gift Card Customer</a></li>
-				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.info.html" target="_blank">Customer Info</a></li>
-					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.redeem.html" target="_blank">Customer Redeem</a></li></ul>
+			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/enterprise_giftCard.html">Enterprise Gift Card</a></strong></li>
+			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cartGiftCard.html">Cart Gift Card</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.add.html">Gift Card Add</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.list.html">Gift Card List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/cartGiftCard/cart_giftcard.remove.html">Gift Card Remove</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftCardAccount.html">Gift Card Account</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.create.html">Account Create</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.info.html">Account Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.list.html">Account List</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.remove.html">Account Remove</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardAccount/giftcard_account.update.html">Account Update</a></li></ul>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftCardCustomer.html">Gift Card Customer</a></li>
+				<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.info.html">Customer Info</a></li>
+					<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftCard/giftCardCustomer/giftcard_customer.redeem.html">Customer Redeem</a></li></ul>
 			</ul>
-			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftMessage.html" target="_blank">Enterprise Gift Message</a></strong></li>
-			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuote.html" target="_blank">Set For Quote</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteItem.html" target="_blank">Set For Quote Item</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteProduct.html" target="_blank">Set For Quote Product</a></li></ul>
+			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftMessage.html">Enterprise Gift Message</a></strong></li>
+			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuote.html">Set For Quote</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteItem.html">Set For Quote Item</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/enterpriseGiftMessage/giftmessage.setForQuoteProduct.html">Set For Quote Product</a></li></ul>
 			
-			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/miscellaneous.html" target="_blank">Miscellaneous</a></strong></li>
-			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/magento.info.html" target="_blank">Magento Info</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.info.html" target="_blank">Store Info</a></li>
-				<li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.list.html" target="_blank">Store List</a></li></ul>
-			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/wsi_compliance.html" target="_blank">WS-I Compliance</a></strong></li>
+			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/miscellaneous.html">Miscellaneous</a></strong></li>
+			<ul><li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/magento.info.html">Magento Info</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.info.html">Store Info</a></li>
+				<li><a href="{{ site.m1xgdeurl }}/api/soap/miscellaneous/store.list.html">Store List</a></li></ul>
+			<li><strong><a href="{{ site.m1xgdeurl }}/api/soap/wsi_compliance.html">WS-I Compliance</a></strong></li>
 			</ul>


### PR DESCRIPTION
Removed target blank for each link of [soap-api-index.html](https://devdocs-openmage.org/guides/m1x/api/soap-api-index.html).
To allow browser back button, and to not open a new tab.