### PR TITLE
Fixed sample call for xmlrpc with 1 parameter

### DIFF
--- a/guides/m1x/api/soap/introduction.html
+++ b/guides/m1x/api/soap/introduction.html
@@ -99,7 +99,7 @@ $client-&gt;endSession($session);</pre>
 $session = $client-&gt;call('login', array('apiUser', 'apiKey'));
 
 $client-&gt;call('call', array($session, 'somestuff.method', array('arg1', 'arg2', 'arg3')));
-$client-&gt;call('call', array($session, 'somestuff.method', 'arg1'));
+$client-&gt;call('call', array($session, 'somestuff.method', array('arg1'));
 $client-&gt;call('call', array($session, 'somestuff.method'));
 $client-&gt;call('multiCall', array($session,
      array(

--- a/guides/m1x/api/soap/introduction.html
+++ b/guides/m1x/api/soap/introduction.html
@@ -99,7 +99,7 @@ $client-&gt;endSession($session);</pre>
 $session = $client-&gt;call('login', array('apiUser', 'apiKey'));
 
 $client-&gt;call('call', array($session, 'somestuff.method', array('arg1', 'arg2', 'arg3')));
-$client-&gt;call('call', array($session, 'somestuff.method', array('arg1'));
+$client-&gt;call('call', array($session, 'somestuff.method', array('arg1')));
 $client-&gt;call('call', array($session, 'somestuff.method'));
 $client-&gt;call('multiCall', array($session,
      array(


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

When this pull request is merged, it will...

Sample call for xmlrpc with 1 parameter is now fixed.

## Additional information

List all affected URLs 

- https://devdocs-openmage.org/guides/m1x/api/soap/introduction.html

I need to call sales_order.info like this to get a response:

$client = new Zend_XmlRpc_Client($xmlrpcUrl);
$session = $client->call('login', [$apiUsername, $apiPassword]);

$orderInfo = $client->call('call', [$session, 'sales_order.info', ['<increment_id>']]);
var_dump($orderInfo);
