### PR TITLE
Fix footer style

### DIFF
--- a/common/css/stylesheet.css
+++ b/common/css/stylesheet.css
@@ -698,3 +698,19 @@ a.image:hover {
 {
   float:right;
 }
+
+#footer
+{
+  clear: both;
+  margin-top: 4em;
+  padding: 1em;
+  width:100%;
+  background-color: #000537;
+  box-sizing: border-box;
+}
+
+#imprint
+{
+  position: absolute;
+  right: 1em; 
+}


### PR DESCRIPTION
## This PR is a:

- [ ] New topic
- [ ] Content update
- [ ] Content fix or rewrite
- [x] Bug fix or improvement

## Summary

Fixes the style for footer which overlaps the content area. One thing I noticed is that `common/css/stylesheet.css` is missing the two selectors for the footer which exist in the same file that's hosted on the live site, I guess they were manually modified without being committed?

- Fixes #11
- Fixes #14

## Additional information

List all affected URLs 

- All the URLs with the OM footer.

<!-- (REQUIRED) The Url that this PR will modify -->

<!-- (OPTIONAL) What other information can you provide about this PR? -->

<!--
Thank you for your contribution!

Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/OpenMage/devdocs/blob/master/.github/CONTRIBUTING.md

Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.

We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->
